### PR TITLE
Update requirements.txt for slackclient version fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gpiozero
 pyrebase
 pyyaml
 Adafruit_GPIO
-slackclient
+slackclient>=1.0.0,<2.0.0


### PR DESCRIPTION
Lock slackclient version to <2.0 until migration to version 2x has been done (if we want to). see https://github.com/slackapi/python-slackclient/wiki/Migrating-to-2.x

Without this change, fermenator will barf with "ModuleNotFoundError: No module named 'slackclient'"